### PR TITLE
Add Trio-based Python NTRIP caster

### DIFF
--- a/pycaster/config.py
+++ b/pycaster/config.py
@@ -1,0 +1,17 @@
+import json
+
+
+def load_config(path):
+    """Load configuration from JSON file."""
+    with open(path, 'r', encoding='utf-8') as f:
+        cfg = json.load(f)
+
+    return {
+        "listen_addr": cfg.get("listen_addr", "0.0.0.0"),
+        "listen_port": int(cfg.get("listen_port", 2101)),
+        "max_client": int(cfg.get("max_client", 0)),
+        "max_source": int(cfg.get("max_source", 0)),
+        "max_pending": int(cfg.get("max_pending", 10)),
+        "tokens_client": cfg.get("tokens_client", {}),
+        "tokens_source": cfg.get("tokens_source", {}),
+    }

--- a/pycaster/main.py
+++ b/pycaster/main.py
@@ -1,0 +1,16 @@
+import argparse
+import trio
+from .config import load_config
+from .server import run_server
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple NTRIP caster written in Python/Trio")
+    parser.add_argument('config', nargs='?', default='ntripcaster.json', help='Path to config file')
+    args = parser.parse_args()
+    cfg = load_config(args.config)
+    trio.run(run_server, cfg)
+
+
+if __name__ == '__main__':
+    main()

--- a/pycaster/protocol.py
+++ b/pycaster/protocol.py
@@ -1,0 +1,39 @@
+"""Helpers to parse minimal NTRIP requests."""
+
+
+def parse_request(data):
+    """Parse raw bytes from a newly connected agent."""
+    text = data.decode('utf-8', 'ignore') if isinstance(data, (bytes, bytearray)) else str(data)
+    lines = text.splitlines()
+    if not lines:
+        return None
+
+    first = lines[0]
+    headers = {k.lower(): v.strip() for k, _, v in (line.partition(':') for line in lines[1:]) if k}
+
+    if first.startswith('GET'):
+        parts = first.split()
+        if len(parts) < 2:
+            return None
+        mount = parts[1].lstrip('/')
+        return {
+            'type': 'client',
+            'mountpoint': mount,
+            'auth': headers.get('authorization', ''),
+            'user_agent': headers.get('user-agent', '')
+        }
+
+    if first.startswith('SOURCE'):
+        parts = first.split()
+        if len(parts) < 3:
+            return None
+        passwd = parts[1]
+        mount = parts[2].lstrip('/')
+        return {
+            'type': 'source',
+            'mountpoint': mount,
+            'passwd': passwd,
+            'user_agent': headers.get('source-agent', '')
+        }
+
+    return None

--- a/pycaster/server.py
+++ b/pycaster/server.py
@@ -1,0 +1,75 @@
+import trio
+from .tokens import prepare_tokens, match_token
+from .protocol import parse_request
+
+
+async def handle_agent(stream, cfg, client_tokens, source_tokens, clients, sources, lock):
+    data = b''
+    while b'\r\n\r\n' not in data:
+        chunk = await stream.receive_some(1024)
+        if not chunk:
+            return
+        data += chunk
+        if len(data) > 4096:
+            return
+    req = parse_request(data)
+    if not req:
+        await stream.aclose()
+        return
+    mount = req['mountpoint']
+    if req['type'] == 'client':
+        token = req['auth'].split()[-1] if req['auth'] else ''
+        if not match_token(client_tokens, token, mount):
+            await stream.send_all(b"HTTP/1.0 401 Unauthorized\r\n\r\n")
+            await stream.aclose()
+            return
+        async with lock:
+            clients.setdefault(mount, set()).add(stream)
+        await stream.send_all(b"ICY 200 OK\r\n")
+        try:
+            while True:
+                if await stream.receive_some(1024) == b'':
+                    break
+        finally:
+            async with lock:
+                clients[mount].discard(stream)
+            await stream.aclose()
+    elif req['type'] == 'source':
+        if not match_token(source_tokens, req['passwd'], mount):
+            await stream.send_all(b"ERROR - Bad Password\r\n")
+            await stream.aclose()
+            return
+        async with lock:
+            if mount in sources:
+                await stream.send_all(b"ERROR - Bad Mountpoint\r\n")
+                await stream.aclose()
+                return
+            sources[mount] = stream
+        await stream.send_all(b"ICY 200 OK\r\n")
+        try:
+            while True:
+                data = await stream.receive_some(8192)
+                if not data:
+                    break
+                async with lock:
+                    for client in list(clients.get(mount, [])):
+                        try:
+                            await client.send_all(data)
+                        except Exception:
+                            clients[mount].discard(client)
+        finally:
+            async with lock:
+                sources.pop(mount, None)
+            await stream.aclose()
+
+
+async def run_server(cfg):
+    client_tokens = prepare_tokens(cfg['tokens_client'])
+    source_tokens = cfg['tokens_source']
+    clients = {}
+    sources = {}
+    lock = trio.Lock()
+    listeners = await trio.open_tcp_listeners(cfg['listen_port'], host=cfg['listen_addr'])
+    async with trio.open_nursery() as nursery:
+        for lst in listeners:
+            nursery.start_soon(trio.serve_listeners, lambda s: handle_agent(s, cfg, client_tokens, source_tokens, clients, sources, lock), [lst])

--- a/pycaster/tokens.py
+++ b/pycaster/tokens.py
@@ -1,0 +1,18 @@
+import base64
+
+
+def prepare_tokens(tokens):
+    """Return a dict mapping base64-encoded tokens to mountpoints."""
+    result = {}
+    for key, mount in tokens.items():
+        enc = base64.b64encode(key.encode()).decode()
+        result[enc] = mount
+    return result
+
+
+def match_token(tokens, token, mount):
+    """Return True if token is valid for mount."""
+    mnt = tokens.get(token)
+    if mnt is None:
+        return False
+    return mnt == '*' or mnt.lower() == mount.lower()


### PR DESCRIPTION
## Summary
- implement a small NTRIP caster in Python using Trio
- load configuration from JSON
- parse minimal NTRIP requests and route data between sources and clients

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m py_compile pycaster/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aec78b53083328c9f73f726b506b4