### PR TITLE
Add logging for pycaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ https://github.com/tisyang/ntripcaster/releases/
 + `max_pending`: 整数，允许的无标识客户端（即非client也非source）最大数量，0表示无限制。默认为10.
 + `tokens_client`: object，每一项的名称表示一个 client 密码对，以冒号分隔的用户名和密码。值表示的可以访问的挂载点名称。挂载点支持 `*` 符号，表示可以访问任何挂载点。
 + `tokens_source`: object, 每一项的名称表示一个 source 密码。值表示可以写入数据的挂载点名称。挂载点支持 `*` 符号，表示可以访问任何挂载点。
++ `log_level`: 字符串，日志等级，例如 `INFO`、`DEBUG`，默认为 `INFO`。
++ `log_file`: 字符串，日志输出文件，默认为空代表输出到标准输出。
 
 配置文件示例:
 
@@ -58,9 +60,11 @@ https://github.com/tisyang/ntripcaster/releases/
 	"tokens_client": {
 		"test:test": "*"
 	},
-	"tokens_source": {
-		"test": "*"
-	}
+        "tokens_source": {
+                "test": "*"
+        },
+        "log_level": "INFO",
+        "log_file": null
 }
 
 ```

--- a/ntripcaster.json
+++ b/ntripcaster.json
@@ -7,7 +7,9 @@
 	"tokens_client": {
 		"test:test": "*"
 	},
-	"tokens_source": {
-		"test": "*"
-	}
+        "tokens_source": {
+                "test": "*"
+        },
+        "log_level": "INFO",
+        "log_file": null
 }

--- a/pycaster/config.py
+++ b/pycaster/config.py
@@ -14,4 +14,6 @@ def load_config(path):
         "max_pending": int(cfg.get("max_pending", 10)),
         "tokens_client": cfg.get("tokens_client", {}),
         "tokens_source": cfg.get("tokens_source", {}),
+        "log_level": cfg.get("log_level", "INFO"),
+        "log_file": cfg.get("log_file"),
     }

--- a/pycaster/main.py
+++ b/pycaster/main.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import trio
 import sys
 import os
@@ -20,6 +21,13 @@ def main():
     parser.add_argument('config', nargs='?', default='ntripcaster.json', help='Path to config file')
     args = parser.parse_args()
     cfg = load_config(args.config)
+    log_level = getattr(logging, cfg['log_level'].upper(), logging.INFO)
+    logging.basicConfig(
+        level=log_level,
+        filename=cfg['log_file'],
+        format='%(asctime)s [%(levelname)s] %(message)s'
+    )
+    logging.info('Starting NTRIP caster')
     trio.run(run_server, cfg)
 
 

--- a/pycaster/server.py
+++ b/pycaster/server.py
@@ -1,4 +1,5 @@
 import trio
+import logging
 
 try:
     from pycaster.tokens import prepare_tokens, match_token
@@ -10,28 +11,35 @@ except ImportError:
 
 
 async def handle_agent(stream, cfg, client_tokens, source_tokens, clients, sources, lock):
+    addr = stream.socket.getpeername()
+    logging.info("Connection from %s", addr)
     data = b''
     while b'\r\n\r\n' not in data:
         chunk = await stream.receive_some(1024)
         if not chunk:
+            logging.info("Connection closed before headers from %s", addr)
             return
         data += chunk
         if len(data) > 4096:
+            logging.warning("Header too large from %s", addr)
             return
     req = parse_request(data)
     if not req:
+        logging.warning("Malformed request from %s", addr)
         await stream.aclose()
         return
     mount = req['mountpoint']
     if req['type'] == 'client':
         token = req['auth'].split()[-1] if req['auth'] else ''
         if not match_token(client_tokens, token, mount):
+            logging.warning("Client auth failed for mount %s from %s", mount, addr)
             await stream.send_all(b"HTTP/1.0 401 Unauthorized\r\n\r\n")
             await stream.aclose()
             return
         async with lock:
             clients.setdefault(mount, set()).add(stream)
         await stream.send_all(b"ICY 200 OK\r\n")
+        logging.info("Client connected to %s from %s", mount, addr)
         try:
             while True:
                 if await stream.receive_some(1024) == b'':
@@ -40,18 +48,22 @@ async def handle_agent(stream, cfg, client_tokens, source_tokens, clients, sourc
             async with lock:
                 clients[mount].discard(stream)
             await stream.aclose()
+        logging.info("Client disconnected from %s (%s)", mount, addr)
     elif req['type'] == 'source':
         if not match_token(source_tokens, req['passwd'], mount):
+            logging.warning("Source auth failed for mount %s from %s", mount, addr)
             await stream.send_all(b"ERROR - Bad Password\r\n")
             await stream.aclose()
             return
         async with lock:
             if mount in sources:
+                logging.warning("Mountpoint %s already in use from %s", mount, addr)
                 await stream.send_all(b"ERROR - Bad Mountpoint\r\n")
                 await stream.aclose()
                 return
             sources[mount] = stream
         await stream.send_all(b"ICY 200 OK\r\n")
+        logging.info("Source connected to %s from %s", mount, addr)
         try:
             while True:
                 data = await stream.receive_some(8192)
@@ -67,6 +79,7 @@ async def handle_agent(stream, cfg, client_tokens, source_tokens, clients, sourc
             async with lock:
                 sources.pop(mount, None)
             await stream.aclose()
+        logging.info("Source disconnected from %s (%s)", mount, addr)
 
 
 async def run_server(cfg):
@@ -76,6 +89,7 @@ async def run_server(cfg):
     sources = {}
     lock = trio.Lock()
     listeners = await trio.open_tcp_listeners(cfg['listen_port'], host=cfg['listen_addr'])
+    logging.info('Listening on %s:%s', cfg['listen_addr'], cfg['listen_port'])
     async with trio.open_nursery() as nursery:
         for lst in listeners:
             nursery.start_soon(trio.serve_listeners, lambda s: handle_agent(s, cfg, client_tokens, source_tokens, clients, sources, lock), [lst])


### PR DESCRIPTION
## Summary
- support optional `log_level` and `log_file` in configuration
- configure logging in the launcher
- log connection, authentication and server start events
- document the new options and update example config

## Testing
- `python - <<'EOF'
import pycaster.config as c
print(c.load_config('ntripcaster.json')['log_level'])
EOF`
- `python -m pycaster.main --help` *(fails: ModuleNotFoundError: No module named 'trio')*
- `python run_pycaster.py --help` *(fails: ModuleNotFoundError: No module named 'trio')*

------
https://chatgpt.com/codex/tasks/task_e_685b0d7b28d48332920167345966c912